### PR TITLE
Add license information to repository

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,1 @@
-# gtfs-best-practices
-
-Best Practices for Structuring General Transit Feed Specification Data
-
-# Styling GTFS Best Practices
-
-# License
-
 Except as otherwise noted, the content of this repository is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/), and code samples are licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
The license information is currently shown in a footer of the published page (http://gtfs.org/best-practices/), but this isn't obvious if you're looking at the repo on Github (e.g., to "borrow" some images).

This patch adds explicit license information in the README and in the standard LICENSE.md file.